### PR TITLE
Pagefind search engine, Discord and footer copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ node_modules/
 # Production build
 out/
 
+# Search index
+_pagefind/
+public/_pagefind/
+
 # Logs
 npm-debug.log*
 yarn-debug.log*

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -52,7 +52,7 @@ const navbar = (
       </div>
     }
     projectLink="https://github.com/Handit-AI/handit.ai.git"
-    chatLink="https://discord.gg/wZbW9Bu5"
+    chatLink="https://discord.gg/XCVWYCFen6"
     chatIcon={
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -89,7 +89,7 @@ const navbar = (
 
 const footer = (
   <Footer className="flex-col items-center md:items-start">
-    MIT {new Date().getFullYear()} © Nextra.
+    MIT {new Date().getFullYear()} © Handit.ai
   </Footer>
 );
 

--- a/app/more/contact/page.mdx
+++ b/app/more/contact/page.mdx
@@ -15,7 +15,7 @@ import { Cards } from "nextra/components";
 <Cards>
   <Cards.Card
     title="Discord Community"
-    href="https://discord.gg/wZbW9Bu5"
+    href="https://discord.gg/XCVWYCFen6"
     target="_blank"
     rel="noopener noreferrer"
   >

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,9 @@ import nextra from 'nextra'
 // Set up Nextra with its configuration
 const withNextra = nextra({
   defaultShowCopyCode: true,
+  search: {
+    codeblocks: true
+  }
 })
 
 // Export the final Next.js config with Nextra included

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind"
   },
   "dependencies": {
     "next": "^15.3.2",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "22.15.21",
-    "@types/react": "19.1.5"
+    "@types/react": "19.1.5",
+    "pagefind": "^1.3.0"
   }
 }


### PR DESCRIPTION
# 🚀 Implement Search Engine and Update Links

## 🔄 Changes
- 🔍 Added Pagefind search engine integration for better documentation search
- 💬 Updated Discord community links to new invite URL
- ©️ Updated footer copyright to Handit.ai

## 🛠️ Technical Details
- 🔎 Integrated Pagefind for static search functionality
- 📝 Added postbuild script for search indexing
- 🗑️ Added _pagefind to gitignore
- ⚙️ Configured search with codeblocks support in next.config.mjs

## ✅ Testing
- 🏗️ Build completes successfully with search index generation
- 🔍 Search functionality works in the documentation
- 🔗 Discord links redirect to the correct server
- ™️ Footer displays correct copyright information